### PR TITLE
Add api for querying/submitting/deleting ZTF queue requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,62 @@ plan.plot_target() # Plots the observing conditions
 plan.request_ztf_fields() # Checks in which ZTF fields this object is observable and download plot for them from http://yupana.caltech.edu
 ```
 ![](examples/figures/observation_plot_icecube.png)
+
+# Triggering ZTF
+
+`ztf_plan_obs` can be used for directly scheduling ToO observations with ZTF. 
+This is done through API calls to the `Kowalski` system, managed by the kowalski python manager [penquins](https://github.com/dmitryduev/penquins).
+
+To use this functionality, you must first configure the connection details. You need both an API token, and to know the address of the Kowalski host address.
+You can then set these as environment variables:
+
+```bash
+export KOWALSKI_HOST=something
+export KOWALSKI_API_TOKEM=somethingelse
+```
+
+You can then import helper functions for querying, submitting and deleting ToO schedules:
+
+## Querying
+
+```python
+from ztf_plan_obs.api import get_too_queues
+existing_too_requests = get_too_queues()
+print([x["name"] for x in existing_too_requests["data"]])
+```
+
+## Submitting
+
+```python
+from ztf_plan_obs.api import build_request, submit_request, get_too_queues
+
+queue_name = "ToO_IC220513A_test"
+
+request = build_request(
+    user="yourname",
+    queue_name=queue_name,
+    validity_window_start_mjd=59719.309333333334,
+    validity_window_end_mjd=59719.30988055556,
+    subprogram_name="ToO_Neutrino",
+    field_ids=[427],
+    filter_ids=[1],
+    exposure_times=[600.]
+) 
+print(request)
+submit_request(request)
+
+queue = get_too_queues()
+
+entries = [x["name"] for x in queue["data"]]
+print(entries)
+assert queue_name in entries
+```
+##Deleting
+```python
+from ztf_plan_obs.api import delete_request
+
+queue_name = "ToO_IC220513A_test"
+
+res = delete_request(user="yourname", queue_name=queue_name)
+print(res)
+```

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
         "numpy",
         "astroplan>=0.7",
         "pandas",
+        "penquins",
         "matplotlib",
         "flask",
         "ztfquery>=1.15.7",

--- a/ztf_plan_obs/api.py
+++ b/ztf_plan_obs/api.py
@@ -1,0 +1,136 @@
+from penquins import Kowalski
+import os
+
+
+class APIError(Exception):
+    pass
+
+
+protocol = "https"
+host = os.environ.get("KOWALSKI_HOST", default="localhost")
+port = 443
+
+api_token = os.environ.get("KOWALSKI_API_TOKEN")
+
+if api_token is None:
+    err = "No kowalski API token found. Set the envirnoment variable with \n" \
+          " export KOWALSKI_API_TOKEN=api_token"
+    raise APIError(err)
+
+kowalski = Kowalski(
+    token=api_token,
+    protocol=protocol,
+    host=host,
+    port=port
+)
+if not kowalski.ping():
+    raise APIError("Ping of kowalski with specified token failed. Are you sure this token is correct?")
+
+
+def get_all_queues():
+    res = kowalski.api("get", "/api/triggers/ztf")
+    if res["status"] != "success":
+        raise APIError(f"API call failed with status '{res['status']}'' and message '{res['message']}''")
+    return res
+
+
+def get_too_queues():
+    res = get_all_queues()
+    res["data"] = [x for x in res["data"] if x["is_TOO"]]
+    return res
+
+
+def build_queue_entry(
+        request_id: int,
+        field_id: int,
+        filter_id: int,
+        subprogram_name: str,
+        program_pi: str = "Kulkarni",
+        program_id: int = 2,
+        exposure_time: float = None,
+        ra: float = None,
+        dec: float = None,
+        n_repeats: int = None,
+        max_airmass: float = None
+
+) -> dict:
+    args = locals()
+
+    entry = {}
+
+    for key, val in args.items():
+        if val is not None:
+            entry[key] = val
+
+    if subprogram_name[:4] != "ToO_":
+        raise ValueError(f"Queue subprogram names must begin with 'ToO_', but you entered '{subprogram_name}'")
+
+    return entry
+
+
+def build_request(
+        user: str,
+        queue_name: str,
+        validity_window_start_mjd: float,
+        validity_window_end_mjd: float,
+        subprogram_name: str,
+        field_ids: list,
+        filter_ids: list,
+        exposure_times: list = None,
+        program_id: int = 2,
+        program_pi: str = "Kulkarni"
+):
+    if queue_name[:4] != "ToO_":
+        raise ValueError(f"Queue names must begin with 'ToO_', but you entered '{queue_name}'")
+
+    targets = []
+
+    for i, field_id in enumerate(field_ids):
+
+        if exposure_times is None:
+            exp_time = None
+        else:
+            exp_time = exposure_times[i]
+
+        target = build_queue_entry(
+            request_id=i,
+            field_id=field_id,
+            filter_id=filter_ids[i],
+            subprogram_name=subprogram_name,
+            program_pi=program_pi,
+            program_id=program_id,
+            exposure_time=exp_time
+        )
+        targets.append(target)
+
+    payload = {
+        "user": user,
+        "queue_name": queue_name,
+        "queue_type": "list",
+        "validity_window_mjd": [
+            validity_window_start_mjd,
+            validity_window_end_mjd
+        ],
+        "targets": targets
+    }
+    return payload
+
+
+def submit_request(payload):
+    return kowalski.api(method="put", endpoint="/api/triggers/ztf", data=payload)
+
+
+def delete_request(
+        user,
+        queue_name
+):
+    req = {
+        "user": user,
+        "queue_name": queue_name
+    }
+
+    return kowalski.api(method="delete", endpoint="/api/triggers/ztf", data=req)
+
+
+
+


### PR DESCRIPTION
This PR adds api.py, for querying/submitting/deleting ZTF requests. Right now this is all just under api.py, with examples in the README, and an updated requirement list in setup.py. It does not include modifications to the slackbot, but that would be an obvious next step.